### PR TITLE
Ignore damage events for non-breakable props

### DIFF
--- a/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
+++ b/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
@@ -37,7 +37,6 @@ end
 local function validateExplosion( ent, dmg )
     if isNonBreakable( ent ) then return false end
 
-
     local pos = dmg:GetDamagePosition()
 
     if not pos then return end

--- a/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
+++ b/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
@@ -28,6 +28,8 @@ function CFCExplosionAntispam.stopAllDamage( duration )
 end
 
 local function validateExplosion( ent, dmg )
+    if ent:GetClass() == "prop_physics" and ent:GetMaxHealth() <= 1 then return false end
+
     local pos = dmg:GetDamagePosition()
 
     if not pos then return end

--- a/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
+++ b/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
@@ -27,12 +27,16 @@ function CFCExplosionAntispam.stopAllDamage( duration )
     end
 end
 
-local function validateExplosion( ent, dmg )
-    if ent:GetClass() == "prop_physics" then -- Ignore non-breakable props
-        local kv = ent:GetKeyValues()
+local function isNonBreakable( ent )
+    if ent:GetClass() ~= "prop_physics" then return false end
+    
+    local kv  = ent:GetKeyValues()
+    return kv.max_health == 1 and kv.ExplodeDamage == 0
+end
 
-        if kv.max_health == 1 and kv.ExplodeDamage == 0 then return false end
-    end
+local function validateExplosion( ent, dmg )
+    if isNonBreakable( ent ) then return false end
+
 
     local pos = dmg:GetDamagePosition()
 

--- a/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
+++ b/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
@@ -28,7 +28,11 @@ function CFCExplosionAntispam.stopAllDamage( duration )
 end
 
 local function validateExplosion( ent, dmg )
-    if ent:GetClass() == "prop_physics" and ent:GetMaxHealth() <= 1 then return false end
+    if ent:GetClass() == "prop_physics" then -- Ignore non-breakable props
+        local kv = ent:GetKeyValues()
+
+        if kv.max_health == 1 and kv.ExplodeDamage == 0 then return false end
+    end
 
     local pos = dmg:GetDamagePosition()
 


### PR DESCRIPTION
This will prevent Explosion Antispam from blocking damage SPD done to groups of regular, non-breakable props.