### PR TITLE
Prevent Explosion Antispam from drastically lowering the impact of ACF and SPD hooks on explosives

### DIFF
--- a/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
+++ b/lua/autorun/server/sv_cfc_explosion_antispam_init.lua
@@ -97,6 +97,6 @@ hook.Add( "EntityTakeDamage", "CFC_ExplosionAntispam_RestrictDamage", function( 
     if clearTime == true then return true end
 
     logDamage( pos, clearTime )
-end )
+end, HOOK_LOW )
 
 hook.Add( "z_anticrash_LagEvent_FoundOffender", "CFC_ExplosionAntispam_StopAllDamage", function() CFCExplosionAntispam.stopAllDamage() end )


### PR DESCRIPTION
Currently, Explosion Antispam neuters the effectiveness of explosives in terms of their use with SPD, and it likely does the same to ACF. SPD and ACF should be able to handle their work before we cancel the explosion.